### PR TITLE
@mzikherman => dont include symbol if symbol is not in OK_SYMBOLS

### DIFF
--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -41,7 +41,7 @@ module MoneyHelper
     symbol = symbol_for_code(currency)
     if SYMBOL_ONLY.include?(currency)
       symbol
-    elsif symbol
+    elsif symbol && OK_SYMBOLS.include?(symbol)
       "#{iso_for_currency(currency)} #{symbol}"
     else
       "#{iso_for_currency(currency)}"

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -192,4 +192,19 @@ describe MoneyHelper do
       expect(MoneyHelper.money_range_to_text(10_000, 20_000, "ITL")).to eql("ITL 10,000 - 20,000")
     end
   end
+  describe "symbol_with_optional_iso_code" do
+    it "returns the symbol only if currency is in SYMBOL_ONLY list" do
+      expect(MoneyHelper.symbol_with_optional_iso_code("EUR")).to eql("€")
+      expect(MoneyHelper.symbol_with_optional_iso_code("USD")).to eql("$")
+    end
+    it "returns iso code and symbol if symbol is in OK_SYMBOLS" do
+      expect(MoneyHelper.symbol_with_optional_iso_code("INR")).to eql("INR ₹")
+      expect(MoneyHelper.symbol_with_optional_iso_code("KHR")).to eql("KHR ៛")
+      expect(MoneyHelper.symbol_with_optional_iso_code("KPW")).to eql("KPW ₩")
+    end
+    it "returns only the iso code if symbol is not in OK_SYMBOLS" do
+      expect(MoneyHelper.symbol_with_optional_iso_code("CHF")).to eql("CHF")
+      expect(MoneyHelper.symbol_with_optional_iso_code("YER")).to eql("YER")
+    end
+  end
 end


### PR DESCRIPTION
We want to follow the logic in `money_to_text`, where we ignore the "symbol" if it is not well-recognized.

We were running into this issue when trying to display the currency/symbol for Swiss Francs. In all of our money formatting code, we saw `CHF 3,000`, while passing the symbol over to clients would return `CHF Fr` because it was using this method. This should be consistent, so we add the additional check to `OK_SYMBOLS` here.
