### PR TITLE
Remove limitation of version for dependent gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "http://rubygems.org"
 
 gemspec
+
+group :development, :test do
+  gem 'rspec', '~> 3.5'
+end

--- a/money_helper.gemspec
+++ b/money_helper.gemspec
@@ -9,8 +9,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/*.rb']
   s.test_files  = Dir['spec/*.rb']
   s.homepage    = 'https://github.com/syakhmi/money_helper'
-  s.add_dependency('money', '~> 6.5')
-  s.add_dependency('activesupport', '~> 4')
-  s.add_development_dependency('rspec', '~> 3')
+  s.add_dependency('money', '>= 6.5')
+  s.add_dependency('activesupport')
   s.licenses = ['MIT']
 end


### PR DESCRIPTION
There's no reason to lock down to ActiveSupport 4 - 5 works as well. Same with Money.